### PR TITLE
Update example YAML to use arrays for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ steps:
     env:
       HOCKEYAPP_APP_ID: 123456789abcdef
     plugins:
-      hockeyapp-upload:
-        path-ipa: .ci-artifacts/Xyzzy.ipa
-        path-dsym-zip: .ci-artifacts/Xyzzy.app.dSYM.zip
-        notify: true
+      - hockeyapp-upload:
+          path-ipa: .ci-artifacts/Xyzzy.ipa
+          path-dsym-zip: .ci-artifacts/Xyzzy.app.dSYM.zip
+          notify: true
 ```
 
 ## Configuring


### PR DESCRIPTION
Hi again @cysp! 😊

(This is the same as https://github.com/cysp/sentry-dsym-upload-buildkite-plugin/pull/1, but I'm not sure which one you'll get to first, so here's all the info again!)

Harriet from Buildkite here 👋🏻 We’ve [updated](https://buildkite.com/changelog/45-updated-syntax-for-using-plugins-in-your-pipeline-yaml) our recommended plugin syntax to use arrays instead of a map, to help ensure plugins are executed in the correct order with all agent versions.

This PR updates your readme example to be the new recommended syntax, and makes them pass the latest [plugin-linter](https://github.com/buildkite-plugins/buildkite-plugin-linter) checks.

Let me know if you have any questions! We’d love to get the readme updated so people use the new best-practice syntax.